### PR TITLE
Deals with the deprecation of request.site in wagtail 2.9

### DIFF
--- a/longclaw/checkout/gateways/braintree.py
+++ b/longclaw/checkout/gateways/braintree.py
@@ -55,7 +55,7 @@ class PaypalVZeroPayment(BasePayment):
         self.gateway = braintree.BraintreeGateway(access_token=settings.VZERO_ACCESS_TOKEN)
 
     def create_payment(self, request, amount, description=''):
-        config = Configuration.for_site(request.site)
+        config = Configuration.for_request(request)
         nonce = request.POST.get('payment_method_nonce')
         result = self.gateway.transaction.sale({
             "amount": str(amount),

--- a/longclaw/checkout/gateways/stripe.py
+++ b/longclaw/checkout/gateways/stripe.py
@@ -15,7 +15,7 @@ class StripePayment(BasePayment):
 
     def create_payment(self, request, amount, description=''):
         try:
-            currency = Configuration.for_site(request.site).currency
+            currency = Configuration.for_request(request).currency
             charge = stripe.Charge.create(
                 amount=int(math.ceil(amount * 100)),  # Amount in pence
                 currency=currency.lower(),

--- a/longclaw/checkout/utils.py
+++ b/longclaw/checkout/utils.py
@@ -64,7 +64,7 @@ def create_order(email,
 
     ip_address = get_client_ip(request)
     if shipping_country and shipping_option:
-        site_settings = Configuration.for_site(request.site)
+        site_settings = Configuration.for_request(request)
         shipping_rate = get_shipping_cost(
             site_settings,
             shipping_address.country.pk,

--- a/longclaw/configuration/context_processors.py
+++ b/longclaw/configuration/context_processors.py
@@ -1,7 +1,7 @@
 from longclaw.configuration.models import Configuration
 
 def currency(request):
-    config = Configuration.for_site(request.site)
+    config = Configuration.for_request(request)
     return {
         'currency_html_code': config.currency_html_code,
         'currency': config.currency

--- a/longclaw/shipping/api.py
+++ b/longclaw/shipping/api.py
@@ -52,7 +52,7 @@ def get_shipping_cost_kwargs(request, country=None):
 
     bid = basket_id(request)
     option = request.query_params.get('shipping_rate_name', 'standard')
-    settings = Configuration.for_site(request.site)
+    settings = Configuration.for_request(request)
     
     return dict(country_code=country_code, destination=destination, basket_id=bid, settings=settings, name=option)
 

--- a/longclaw/shipping/templatetags/longclawshipping_tags.py
+++ b/longclaw/shipping/templatetags/longclawshipping_tags.py
@@ -9,7 +9,7 @@ register = template.Library()
 def shipping_rate(context, **kwargs):
     """Return the shipping rate for a country & shipping option name.
     """
-    settings = Configuration.for_site(context["request"].site)
+    settings = Configuration.for_request(context["request"])
     code = kwargs.get('code', None)
     name = kwargs.get('name', None)
     return get_shipping_cost(settings, code, name)

--- a/longclaw/shipping/tests.py
+++ b/longclaw/shipping/tests.py
@@ -71,7 +71,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], 'US')
         self.assertEqual(result['destination'], None)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'standard')
     
     def test_get_shipping_cost_kwargs_country_code_and_shipping_rate_name(self):
@@ -81,7 +81,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], 'US')
         self.assertEqual(result['destination'], None)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'foo')
     
     def test_get_shipping_cost_kwargs_only_country(self):
@@ -91,7 +91,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], self.country.pk)
         self.assertEqual(result['destination'], None)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'standard')
     
     def test_get_shipping_cost_kwargs_only_country_known_iso(self):
@@ -102,7 +102,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], 'ZZ')
         self.assertEqual(result['destination'], None)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'standard')
     
     def test_get_shipping_cost_kwargs_with_destination(self):
@@ -113,7 +113,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], destination.country.pk)
         self.assertEqual(result['destination'], destination)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'standard')
     
     def test_get_shipping_cost_kwargs_with_destination_and_country_code(self):
@@ -125,7 +125,7 @@ class ShippingTests(LongclawTestCase):
         self.assertEqual(result['country_code'], '11')
         self.assertEqual(result['destination'], destination)
         self.assertEqual(result['basket_id'], basket_id(api_request))
-        self.assertEqual(result['settings'], Configuration.for_site(api_request.site))
+        self.assertEqual(result['settings'], Configuration.for_request(api_request))
         self.assertEqual(result['name'], 'standard')
     
     def test_create_address(self):

--- a/longclaw/stats/wagtail_hooks.py
+++ b/longclaw/stats/wagtail_hooks.py
@@ -48,7 +48,7 @@ class ProductCount(LongclawSummaryItem):
 class MonthlySales(LongclawSummaryItem):
     order = 30
     def get_context(self):
-        settings = Configuration.for_site(self.request.site)
+        settings = Configuration.for_request(self.request)
         sales = stats.sales_for_time_period(*stats.current_month())
         return {
             'total': "{}{}".format(settings.currency_html_code,


### PR DESCRIPTION
While working with the longclaw_demo I discovered a site middleware change that happens at v2.9 https://docs.wagtail.org/en/stable/releases/2.9.html#sitemiddleware-and-request-site-deprecated needs to be updated.

The current version support for the master branch is: wagtail>=2.11,<2.14, hence the changes here.

This updates package code and tests where request.site was used previously.